### PR TITLE
Fix two bugs on the sort_diagonal path, and skip prepare's no-op change of basis

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,122 @@
+# Convergence basin of the IPT iteration
+
+Notes from a numerical study of *when* the fixed-point iteration converges, and what
+does and does not enlarge that region. Reproduce with:
+
+```
+julia --project research/basin_theory.jl
+```
+
+Test family throughout: `D + t*W`, with `D = diagm(1:N)` (unit level spacing) and `W`
+a dense symmetric Gaussian matrix with zero diagonal. So `t` is the coupling strength
+measured in units of the level spacing. All runs use `sort_diagonal = false,
+lift_degeneracies = false` to isolate the iteration itself, and `k = N`.
+
+## The map and its Jacobian
+
+Writing `M = D + V` with `D = diag(M)`, `quadratic!` implements
+
+    F(X)_ij = [ (VX)_ij - X_ij (VX)_jj ] / (d_j - d_i),    F(X)_jj = 1
+
+whose fixed points are eigenmatrices in the gauge `diag(X) = 1`. Differentiating at a
+fixed point `X*`:
+
+    J[E]_ij = [ (VE)_ij - E_ij (VX*)_jj - X*_ij (VE)_jj ] / (d_j - d_i),   E_jj = 0
+
+This is validated sharply: plain Picard (`acceleration = :none`) converges at t = 0.40
+where rho(J) = 0.92, and fails at t = 0.42 where rho(J) = 0.98. The rho = 1 crossing
+predicts the Picard barrier to within one grid step.
+
+## Main result: the operative criterion is max Re(mu) < 1, not rho < 1
+
+ACX converges far past rho = 1 -- it is not accelerating a contraction, it is
+*stabilising an unstable fixed point*. Its sigma-extrapolation of order p applies
+
+    (I + sigma (J - I))^p
+
+to the error, so eigenvalues of J move as mu -> (1 + sigma(mu - 1))^p. Stability needs
+|1 + sigma(mu - 1)| < 1, and as sigma -> 0 that region opens up to the entire half-plane
+
+    Re(mu) < 1
+
+independently of p. Measured at N = 30 (identity gauge):
+
+| t | rho(J) | max Re(mu) | Re < 1 | ACX converges |
+|---|---|---|---|---|
+| 0.30 | 0.668 | 0.539 | yes | yes |
+| 0.50 | 1.433 | 0.838 | yes | yes |
+| 0.70 | 2.144 | 0.727 | yes | yes |
+| 0.90 | 2.998 | 0.885 | yes | **no** |
+| 1.10 | 9.181 | 9.181 | no | no |
+| 1.30 | 93.261 | 24.898 | no | no |
+
+At t = 0.70, rho = 2.14 >> 1 yet ACX converges, because the unstable eigenvalues sit far
+out on the *negative* real axis where the extrapolation folds them back. This is why the
+method works well past where the naive "perturbation smaller than the gap" rule predicts.
+
+The criterion is necessary, not sufficient -- t = 0.90 has max Re(mu) = 0.885 < 1 and
+still fails. Two reasons: ACX picks sigma adaptively from difference ratios rather than
+optimally, and the admissible window is narrow when max Re(mu) is just under 1; and the
+criterion is local, whereas a cold start from X0 = I is a global basin question.
+
+## Things that do not enlarge the basin
+
+Baseline cold ACX at N = 60 reaches t = 0.85. Five approaches, all falsified:
+
+| approach | reach | why it fails |
+|---|---|---|
+| cold ACX (baseline) | 0.85 | |
+| continuation in t | 0.85 | enforces the adiabatic assignment, which is the thing going singular |
+| block-Jacobi b = 2 / 4 / 8 | 0.60 / 0.50 / 0.65 | block rotation collapses inter-block gaps |
+| higher `acx_orders` | 0.85 | stability region shape is p-independent |
+| gauge re-anchoring | < 0.80 | target fixed point has Re(mu) > 1, unstabilisable |
+| Brillouin-Wigner denominators | 0.55 | intruder states: lambda_j - d_i passes through zero |
+
+Detail on the two least obvious:
+
+**Block-Jacobi backfires.** Diagonalising consecutive blocks exactly should reduce the
+effective coupling, but rotating a block *spreads* its eigenvalues, and the spread
+eigenvalues of neighbouring blocks approach each other. The measured minimum gap after
+b = 2 blocking falls from 0.66 at t = 0.4 to 0.011 at t = 0.85 -- far below the unrotated
+spacing of 1. It destroys more gap than the exact intra-block treatment buys. A blocking
+chosen to avoid creating small inter-block gaps might still pay off; consecutive blocking
+does not.
+
+**Gauge re-anchoring looked promising and is not.** At t = 0.85 the identity labelling is
+nearly singular (min|v_jj| = 0.080, so ||X*|| -> infinity) while a greedy max-overlap
+re-assignment stays healthy (0.318, and 12x better at t = 0.9). The eigenvectors are still
+localised -- just on different reference states than the identity labelling assumes. But
+the re-assigned fixed point is *never attracting*: perturbing it by a relative 1e-8 and
+iterating fails to return, at every t tested, while the identity fixed point recovers from
+a relative 1e-1 perturbation at t = 0.85. The Re(mu) criterion explains why: at t = 0.70
+the two gauges have near-identical rho (2.14 vs 2.42) but max Re(mu) of 0.727 vs **1.611**.
+The better-conditioned, lower-rho fixed point has Jacobian eigenvalues with Re > 1, which
+no sigma stabilises at any order. It is unreachable in principle, not merely hard to find.
+
+**Brillouin-Wigner.** Replacing the RS denominators with self-consistent ones,
+
+    F(X)_ij = (VX)_ij / (lambda_j(X) - d_i),   lambda_j(X) = d_j + (VX)_jj
+
+has *identical* fixed points (substitute lambda_j to recover the RS condition) but a
+different Jacobian, which drops the E_ij (VX)_jj term into the denominator. It is better
+at very weak coupling (rho 1.08 vs 1.43 at t = 0.5) and much worse beyond: at t = 0.70,
+max Re(mu) = 28.4 against RS's 0.727. The classic intruder-state problem -- lambda_j
+drifts towards a neighbouring d_i and the denominator passes through zero.
+
+## Where this points
+
+The accelerator, the gauge, and the starting point are all *not* the binding constraint.
+What matters is where the spectrum of J sits relative to the line Re(mu) = 1, and none of
+the five moves it left. Any real enlargement has to change the map so that spectrum shifts
+-- BW was the obvious candidate and it moves the wrong way because of intruder states, so
+a denominator regularisation that keeps the self-consistency while bounding
+|lambda_j - d_i| away from zero is the natural next thing to try.
+
+Two untested gaps worth flagging:
+
+- `acceleration = :anderson` was not measured. It is the one accelerator whose stability
+  region is *not* of the form |1 + sigma(mu - 1)| < 1 -- it builds its step from a
+  subspace rather than one scalar per column, so it could in principle stabilise
+  Re(mu) > 1. If so, the analysis above bounds ACX specifically, not the method.
+- Everything here is a single realisation of one coupling family at N in {30, 60}. The
+  *form* of the criterion should be generic; the thresholds certainly are not.

--- a/research/README.md
+++ b/research/README.md
@@ -29,6 +29,8 @@ predicts the Picard barrier to within one grid step.
 
 ## Main result: the operative criterion is max Re(mu) < 1, not rho < 1
 
+(This bounds ACX specifically. Anderson is not subject to it -- see below.)
+
 ACX converges far past rho = 1 -- it is not accelerating a contraction, it is
 *stabilising an unstable fixed point*. Its sigma-extrapolation of order p applies
 
@@ -59,6 +61,43 @@ still fails. Two reasons: ACX picks sigma adaptively from difference ratios rath
 optimally, and the admissible window is narrow when max Re(mu) is just under 1; and the
 criterion is local, whereas a cold start from X0 = I is a global basin question.
 
+## What does help: Anderson with large memory
+
+ACX applies a *fixed-shape* polynomial driven by one scalar per column, so it is
+confined to the region above. Anderson acceleration instead builds an optimal
+degree-m polynomial from the residual history -- GMRES-like on (I - J) -- and is
+therefore not confined to Re(mu) < 1. It isn't:
+
+| t | max Re(mu) | Re < 1 | ACX | AA m=50 | AA m=50 beta=0.2 |
+|---|---|---|---|---|---|
+| 0.70 | 0.727 | yes | yes | yes | yes |
+| 0.90 | 0.885 | yes | **no** | yes | yes |
+| 1.00 | 0.983 | yes | **no** | yes | yes |
+| 1.10 | 9.181 | **no** | no | **yes** | **yes** |
+| 1.30 | 24.898 | no | no | no | no |
+
+Anderson converges at t = 1.10 where max Re(mu) = 9.18, which no sigma stabilises at
+any order. It also clears t = 0.90 and 1.00, where max Re(mu) is just under 1 and ACX
+fails because its adaptively chosen sigma does not land in the narrow admissible
+window. Anderson is bounded too, somewhere between max Re(mu) = 9 and 25.
+
+**Memory matters, and the package default is too small.** Reach at N = 60:
+
+| accelerator | t_max |
+|---|---|
+| ACX [3,2] (default) | 0.85 |
+| Anderson m=2 | 0.70 |
+| Anderson m=5 (`anderson_memory` default) | 0.80 |
+| Anderson m=10 / m=20 | 0.85 |
+| Anderson m=50 | 0.90 |
+| Anderson m=20, beta=0.2 | 0.90 |
+
+At the default `anderson_memory = 5`, Anderson is *worse* than ACX and there is no
+reason to switch. The gain only appears at m >~ 20-50. So for strongly coupled
+problems the recommendation is `acceleration = :anderson` **with the memory raised**,
+not simply switching accelerator. Damping (beta < 1) buys about as much as raising m
+and is cheaper.
+
 ## Things that do not enlarge the basin
 
 Baseline cold ACX at N = 60 reaches t = 0.85. Five approaches, all falsified:
@@ -69,7 +108,7 @@ Baseline cold ACX at N = 60 reaches t = 0.85. Five approaches, all falsified:
 | continuation in t | 0.85 | enforces the adiabatic assignment, which is the thing going singular |
 | block-Jacobi b = 2 / 4 / 8 | 0.60 / 0.50 / 0.65 | block rotation collapses inter-block gaps |
 | higher `acx_orders` | 0.85 | stability region shape is p-independent |
-| gauge re-anchoring | < 0.80 | target fixed point has Re(mu) > 1, unstabilisable |
+| gauge re-anchoring | < 0.80 | target fixed point has Re(mu) > 1, unstabilisable by ACX |
 | Brillouin-Wigner denominators | 0.55 | intruder states: lambda_j - d_i passes through zero |
 
 Detail on the two least obvious:
@@ -105,18 +144,24 @@ drifts towards a neighbouring d_i and the denominator passes through zero.
 
 ## Where this points
 
-The accelerator, the gauge, and the starting point are all *not* the binding constraint.
-What matters is where the spectrum of J sits relative to the line Re(mu) = 1, and none of
-the five moves it left. Any real enlargement has to change the map so that spectrum shifts
--- BW was the obvious candidate and it moves the wrong way because of intruder states, so
-a denominator regularisation that keeps the self-consistency while bounding
-|lambda_j - d_i| away from zero is the natural next thing to try.
+For the *gauge* and the *starting point*, the conclusion is negative and fairly firm:
+neither is the binding constraint, and re-anchoring in particular chases a fixed point
+that is unreachable in principle. For the *map*, BW moves the spectrum the wrong way
+because of intruder states, so a denominator regularisation that keeps the
+self-consistency while bounding |lambda_j - d_i| away from zero is the natural next
+thing to try.
 
-Two untested gaps worth flagging:
+The *accelerator*, by contrast, turned out to be the one lever that works. Anderson
+with large memory is the only thing measured here that reliably beats the baseline, and
+it does so by escaping the Re(mu) < 1 region rather than by moving the spectrum. Worth
+pursuing further: Anderson is bounded too (it fails by max Re(mu) ~ 25), and where that
+bound comes from is not characterised here. A per-column Anderson -- matching how ACX
+already treats the columns independently, which the map permits since F is
+column-decoupled -- was not tried and is the obvious next experiment.
 
-- `acceleration = :anderson` was not measured. It is the one accelerator whose stability
-  region is *not* of the form |1 + sigma(mu - 1)| < 1 -- it builds its step from a
-  subspace rather than one scalar per column, so it could in principle stabilise
-  Re(mu) > 1. If so, the analysis above bounds ACX specifically, not the method.
-- Everything here is a single realisation of one coupling family at N in {30, 60}. The
-  *form* of the criterion should be generic; the thresholds certainly are not.
+Remaining caveat: everything here is a single realisation of one coupling family at
+N in {30, 60}. The *form* of the criteria should be generic; the thresholds certainly
+are not. The Anderson implementation used is a standalone Walker & Ni type-II in
+`basin_theory.jl`, not the `NLsolve` path that `acceleration = :anderson` actually
+calls, so the reach numbers should be re-checked against the package's own
+implementation before being relied on.

--- a/research/README.md
+++ b/research/README.md
@@ -98,6 +98,41 @@ problems the recommendation is `acceleration = :anderson` **with the memory rais
 not simply switching accelerator. Damping (beta < 1) buys about as much as raising m
 and is cheaper.
 
+### Per-column Anderson does not help, and fails in an instructive way
+
+The map is column-decoupled -- F(X)[:,j] depends only on X[:,j] -- and ACX already
+exploits this with a separate sigma per column. So per-column Anderson (its own
+history and least-squares per column, strictly more freedom at identical cost) looks
+like the obvious next step. It is worse: reach 0.80 at N = 60 against 0.90 for the
+shared-gamma version, and flat in m.
+
+The reason is not divergence. It *converges*, to machine precision, with every column
+a genuine eigenvector -- onto **duplicate** eigenvectors:
+
+| t | per-column resid | cond(X) | distinct eigenvalues | shipped ACX resid | ACX distinct |
+|---|---|---|---|---|---|
+| 0.80 | 7.4e-15 | 6.3e+00 | 60/60 | 4.6e-15 | 60/60 |
+| 0.85 | 3.2e-15 | **4.5e+14** | **57/60** | 1.9e-14 | 60/60 |
+| 0.90 | 3.6e-15 | 6.9e+13 | **59/60** | 6.1e+12 | 21/60 |
+| 1.00 | 6.4e-15 | 4.3e+14 | **57/60** | 1.2e+13 | 0/60 |
+
+This exposes a general property of the stopping test. `maximum(R) < tol` asks that each
+column is *an* eigenvector; it never asks that the columns are *distinct*. A solve can
+therefore report success while several columns have collapsed onto the same eigenvector,
+silently returning a rank-deficient basis with eigenvalues missing. Sharing one gamma
+across columns is what prevents this -- the columns are decoupled in the map, but
+coupling them in the accelerator keeps them from merging. That coupling is a feature,
+not a limitation to be optimised away.
+
+`cond(X)` is a reliable and cheap detector: 6.3 when healthy, 1e13-1e14 on collapse.
+
+Note this is a hazard of per-column Anderson, **not** a defect in the package. On this
+family the shipped ACX path never collapses silently -- when it fails it fails loudly,
+with residuals around 1e12-1e13 that any caller would notice (the ACX columns above are
+diverged, not collapsed). But nothing in the stopping test *guarantees* that, so a
+`cond(X)` or rank check would be cheap insurance for anyone pushing into strong coupling
+or swapping in a different accelerator.
+
 ## Things that do not enlarge the basin
 
 Baseline cold ACX at N = 60 reaches t = 0.85. Five approaches, all falsified:
@@ -155,9 +190,9 @@ The *accelerator*, by contrast, turned out to be the one lever that works. Ander
 with large memory is the only thing measured here that reliably beats the baseline, and
 it does so by escaping the Re(mu) < 1 region rather than by moving the spectrum. Worth
 pursuing further: Anderson is bounded too (it fails by max Re(mu) ~ 25), and where that
-bound comes from is not characterised here. A per-column Anderson -- matching how ACX
-already treats the columns independently, which the map permits since F is
-column-decoupled -- was not tried and is the obvious next experiment.
+bound comes from is not characterised here. Per-column Anderson, the obvious next thing
+to try, was tried and is a dead end -- see above; the interesting part is *why*, and the
+column-collapse hazard it exposes in the stopping test.
 
 Remaining caveat: everything here is a single realisation of one coupling family at
 N in {30, 60}. The *form* of the criteria should be generic; the thresholds certainly

--- a/research/basin_theory.jl
+++ b/research/basin_theory.jl
@@ -1,0 +1,260 @@
+#
+# Numerical study of the convergence basin of the IPT fixed-point iteration.
+#
+# Run with:  julia --project research/basin_theory.jl
+#
+# Summary of what this measures (see research/README.md for the findings):
+#
+# The map implemented by `quadratic!` is, writing M = D + V with D = diag(M),
+#
+#     F(X)_ij = [ (VX)_ij - X_ij (VX)_jj ] / (d_j - d_i),   F(X)_jj = 1
+#
+# Its Jacobian at a fixed point X* governs local convergence:
+#
+#     J[E]_ij = [ (VE)_ij - E_ij (VX*)_jj - X*_ij (VE)_jj ] / (d_j - d_i),  E_jj = 0
+#
+# Picard iteration converges iff rho(J) < 1. ACX does not: its sigma-extrapolation
+# applies (I + sigma(J - I))^p, so the operative condition is max Re(mu) < 1 over
+# the spectrum of J -- a far weaker requirement, and independent of the order p.
+#
+
+using LinearAlgebra, Random, Printf, SparseArrays
+using IterativePerturbationTheory
+const ACX = IterativePerturbationTheory.acx
+
+const OPTS = (; sort_diagonal = false, lift_degeneracies = false)
+
+# ---------------------------------------------------------------- test family
+# Uniform level spacing, dense symmetric coupling with zero diagonal, so that
+# t is directly the coupling strength measured in units of the level spacing.
+function testfamily(N; seed = 2024)
+    Random.seed!(seed)
+    W = randn(N, N); W = (W + W') / 2; W[diagind(W)] .= 0
+    D = diagm(0 => collect(1.0:N))
+    t -> D + t * W, W
+end
+
+spectrum_of(A) = eigen(Symmetric(A)).values
+
+"""Did the solve recover the whole spectrum, to eigenvector accuracy?"""
+function solved(A, vectors, values; tol = 1e-8)
+    all(isfinite, values) || return false
+    norm(A * vectors - vectors * Diagonal(values)) / norm(A) < tol || return false
+    maximum(abs, sort(real(values)) .- spectrum_of(A)) < 1e-6
+end
+
+quiet(f) = redirect_stdout(devnull) do; f(); end
+
+function solve_rs(A, k = size(A, 1); orders = [3, 2], tol = 1e-12, maxiter = 4000, X0 = nothing)
+    quiet() do
+        try
+            X0 === nothing ? ipt(A, k; tol, maxiter, acx_orders = orders, OPTS...) :
+                             ipt(A, k, copy(X0); tol, maxiter, acx_orders = orders, OPTS...)
+        catch
+            nothing
+        end
+    end
+end
+
+# ------------------------------------------------------- Brillouin-Wigner map
+# Same fixed points as the RS map above, but with self-consistent denominators
+# lambda_j - d_i recomputed every step. Substituting lambda_j = d_j + (VX)_jj
+# into its fixed-point condition recovers the RS one exactly.
+function solve_bw(A, k = size(A, 1); orders = [3, 2], tol = 1e-12, maxiter = 4000)
+    d = diag(A); T = eltype(A); Dg = Diagonal(d)
+    function F!(Y, X)
+        mul!(Y, A, X)
+        R = vec(mapslices(norm, Y .- X * Diagonal(Y); dims = 1))
+        mul!(Y, Dg, X, -one(T), one(T))          # Y = V X
+        lam = d[1:k] .+ diag(Y)                  # lambda_j = d_j + (VX)_jj
+        Y ./= (transpose(lam) .- d)
+        Y[diagind(Y)] .= one(T)
+        R
+    end
+    s = quiet() do
+        ACX(F!, Matrix{T}(I, size(A, 1), k); tol, orders, maxiter, matrix = A)
+    end
+    (vectors = s.solution, values = diag(A * s.solution), iters = s.f_calls)
+end
+
+# ------------------------------------------------------------------- gauges
+"""Fixed point with column j anchored on reference j (the gauge `ipt` uses)."""
+unit_gauge(A) = (Vec = eigen(Symmetric(A)).vectors; Vec * Diagonal(1 ./ diag(Vec)))
+
+"""Greedy max-overlap matching of reference states to eigenvectors."""
+function greedy_assign(Vec)
+    n = size(Vec, 1); Am = abs.(Vec)
+    rows = trues(n); cols = trues(n); p = zeros(Int, n)
+    for _ in 1:n
+        best = -1.0; bi = bj = 0
+        for j in 1:n, i in 1:n
+            if rows[i] && cols[j] && Am[i, j] > best; best = Am[i, j]; bi, bj = i, j; end
+        end
+        rows[bi] = false; cols[bj] = false; p[bi] = bj
+    end
+    p
+end
+
+function greedy_gauge(A)
+    Vec = eigen(Symmetric(A)).vectors; p = greedy_assign(Vec)
+    X = similar(Vec)
+    for m in axes(Vec, 1); X[:, m] = Vec[:, p[m]] / Vec[m, p[m]]; end
+    X
+end
+
+# ---------------------------------------------------------------- Jacobians
+function jacobian_apply(kind, E, Vt, Xs, d)
+    VE, VXs = Vt * E, Vt * Xs
+    lam = d .+ diag(VXs)
+    J = zeros(eltype(E), size(E))
+    for j in axes(E, 2), i in axes(E, 1)
+        i == j && continue
+        J[i, j] = kind === :rs ?
+            (VE[i, j] - E[i, j] * VXs[j, j] - Xs[i, j] * VE[j, j]) / (d[j] - d[i]) :
+            (VE[i, j] - Xs[i, j] * VE[j, j]) / (lam[j] - d[i])
+    end
+    J
+end
+
+"""Dominant |mu| by power iteration -- cheap, no explicit matrix."""
+function spectral_radius(kind, Vt, Xs, d; iters = 400, seed = 1)
+    Random.seed!(seed)
+    E = randn(size(Xs)); E[diagind(E)] .= 0; E ./= norm(E); r = 0.0
+    for _ in 1:iters
+        E2 = jacobian_apply(kind, E, Vt, Xs, d)
+        r = norm(E2)
+        isfinite(r) || return Inf
+        r < 1e-300 && return 0.0
+        E = E2 ./ r
+    end
+    r
+end
+
+"""Full spectrum of J -- builds the explicit matrix, so keep N modest."""
+function jacobian_spectrum(kind, Vt, Xs, d)
+    N = size(Xs, 1)
+    idx = [(i, j) for j in 1:N for i in 1:N if i != j]
+    m = length(idx); Jm = zeros(m, m)
+    for (c, (i, j)) in enumerate(idx)
+        E = zeros(N, N); E[i, j] = 1.0
+        Y = jacobian_apply(kind, E, Vt, Xs, d)
+        for (r, (a, b)) in enumerate(idx); Jm[r, c] = Y[a, b]; end
+    end
+    eigvals(Jm)
+end
+
+# ================================================================ experiments
+
+"""rho vs max Re(mu) as predictors of ACX convergence. This is the main result."""
+function experiment_criterion(; N = 30, ts = (0.3, 0.5, 0.7, 0.9, 1.1, 1.3))
+    mk, W = testfamily(N)
+    println("\n== Convergence criterion: rho(J) < 1 vs max Re(mu) < 1 ==")
+    @printf("%-6s %-9s %9s %10s %8s  %s\n", "t", "gauge", "rho", "maxRe(mu)", "Re<1?", "ACX cold")
+    for t in ts
+        A = mk(t); d = diag(A)
+        Z = solve_rs(A); cold = Z !== nothing && solved(A, Z.vectors, Z.values)
+        for (nm, Xs) in (("identity", unit_gauge(A)), ("greedy", greedy_gauge(A)))
+            mu = jacobian_spectrum(:rs, t * W, Xs, d)
+            @printf("%-6.2f %-9s %9.3f %10.3f %8s  %s\n", t, nm, maximum(abs, mu),
+                    maximum(real, mu), maximum(real, mu) < 1 ? "yes" : "NO",
+                    nm == "identity" ? (cold ? "yes" : "NO") : "")
+        end
+    end
+end
+
+"""Is a fixed point attracting? Perturb it and see whether the iteration returns."""
+function experiment_basin(; N = 60, ts = (0.85, 0.9, 1.0, 1.2), eps = (1e-8, 1e-4, 1e-2, 1e-1))
+    mk, _ = testfamily(N)
+    println("\n== Basin: recovery from a relative perturbation (3 trials) ==")
+    @printf("%-6s %-9s | %s\n", "t", "gauge", join([@sprintf("%8.0e", e) for e in eps], " "))
+    for t in ts, (nm, X0) in (("identity", unit_gauge(mk(t))), ("greedy", greedy_gauge(mk(t))))
+        A = mk(t)
+        counts = map(eps) do e
+            n = 0
+            for s in 1:3
+                Random.seed!(100 + s)
+                E = randn(size(X0)); E[diagind(E)] .= 0
+                Xp = X0 .+ (e * norm(X0) / norm(E)) .* E; Xp[diagind(Xp)] .= 1
+                Z = solve_rs(A; X0 = Xp)
+                Z !== nothing && solved(A, Z.vectors, Z.values) && (n += 1)
+            end
+            n
+        end
+        @printf("%-6.2f %-9s | %s\n", t, nm, join([@sprintf("%8d", c) for c in counts], " "))
+    end
+end
+
+"""Largest coupling each strategy reaches. All of these are negative results."""
+function experiment_enlargement(; N = 60, tmax = 1.6, dt = 0.05)
+    mk, W = testfamily(N)
+    reach(f) = (r = 0.0; for t in dt:dt:tmax; (try f(t) catch; false end) ? (r = t) : break; end; r)
+
+    cold(t) = (A = mk(t); Z = solve_rs(A); Z !== nothing && solved(A, Z.vectors, Z.values))
+
+    function continuation(t_target)          # warm-started homotopy in t
+        X = Matrix{Float64}(I, N, N)
+        for t in dt:dt:t_target
+            Z = solve_rs(mk(t); X0 = X)
+            (Z === nothing || !all(isfinite, Z.values)) && return false
+            X = Z.vectors
+        end
+        A = mk(t_target); Z = solve_rs(A; X0 = X)
+        Z !== nothing && solved(A, Z.vectors, Z.values)
+    end
+
+    function blockref(t, b)                  # exact within consecutive blocks
+        A = mk(t); Q = zeros(N, N)
+        for lo in 1:b:N
+            hi = min(lo + b - 1, N)
+            Q[lo:hi, lo:hi] = eigen(Symmetric(A[lo:hi, lo:hi])).vectors
+        end
+        Z = solve_rs(Q' * A * Q)
+        Z !== nothing && solved(A, Q * Z.vectors, Z.values)
+    end
+
+    bw(t) = (A = mk(t); Z = try solve_bw(A) catch; nothing end;
+             Z !== nothing && solved(A, Z.vectors, Z.values))
+
+    println("\n== Reach of each strategy (t_max, larger is better) ==")
+    @printf("  %-34s %.2f\n", "cold ACX (baseline)", reach(cold))
+    @printf("  %-34s %.2f\n", "continuation in t", reach(continuation))
+    for b in (2, 4, 8)
+        @printf("  %-34s %.2f\n", "block-Jacobi reference b=$b", reach(t -> blockref(t, b)))
+    end
+    for ords in ([2], [3], [3, 3, 2])
+        @printf("  %-34s %.2f\n", "acx_orders = $ords",
+                reach(t -> (A = mk(t); Z = solve_rs(A; orders = ords);
+                            Z !== nothing && solved(A, Z.vectors, Z.values))))
+    end
+    @printf("  %-34s %.2f\n", "Brillouin-Wigner denominators", reach(bw))
+end
+
+"""Why block-Jacobi backfires, and how much headroom the gauge appears to offer."""
+function experiment_diagnostics(; N = 60, ts = (0.4, 0.6, 0.8, 0.85, 0.9, 1.0, 1.2, 1.5))
+    mk, _ = testfamily(N)
+    println("\n== Gauge conditioning and block-rotation gap collapse ==")
+    @printf("%-6s %12s %14s %10s\n", "t", "min|v_jj|", "min|v_pi(j)j|", "b=2 gap")
+    for t in ts
+        A = mk(t); Vec = eigen(Symmetric(A)).vectors
+        p = greedy_assign(Vec)
+        gr = minimum(abs(Vec[m, p[m]]) for m in 1:N)
+        Q = zeros(N, N)
+        for lo in 1:2:N
+            hi = min(lo + 1, N)
+            Q[lo:hi, lo:hi] = eigen(Symmetric(A[lo:hi, lo:hi])).vectors
+        end
+        @printf("%-6.2f %12.4f %14.4f %10.4f\n", t, minimum(abs, diag(Vec)), gr,
+                minimum(diff(sort(diag(Q' * A * Q)))))
+    end
+end
+
+function run_all()
+    experiment_criterion()
+    experiment_diagnostics()
+    experiment_basin()
+    experiment_enlargement()
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_all()
+end

--- a/research/basin_theory.jl
+++ b/research/basin_theory.jl
@@ -105,6 +105,55 @@ function anderson(F!, X0; m = 50, beta = 1.0, tol = 1e-12, maxiter = 6000)
     (solution = X, iters = maxiter, ok = false)
 end
 
+# Per-column Anderson. F is column-decoupled, so each column can carry its own
+# history and least-squares solve -- strictly more freedom than the shared-gamma
+# version above, at the same cost. It is *worse*, and for a subtle reason: see
+# experiment_column_collapse and the README. Kept here as a documented dead end.
+function anderson_percolumn(F!, X0; m = 20, beta = 1.0, tol = 1e-12, maxiter = 6000)
+    T = eltype(X0); X = copy(X0); Y = similar(X); N, k = size(X)
+    dX = [Vector{Vector{T}}() for _ in 1:k]; dF = [Vector{Vector{T}}() for _ in 1:k]
+    Xp = similar(X); Fp = similar(X); have = false
+    for it in 1:maxiter
+        R = F!(Y, X)
+        all(isfinite, Y) || return (solution = Y, iters = it, ok = false)
+        maximum(R) < tol && return (solution = copy(Y), iters = it, ok = true)
+        Fc = Y .- X; Xn = similar(X)
+        for c in 1:k
+            x = @view(X[:, c]); f = @view(Fc[:, c])
+            if have
+                push!(dX[c], x .- @view(Xp[:, c])); push!(dF[c], f .- @view(Fp[:, c]))
+                length(dX[c]) > m && (popfirst!(dX[c]); popfirst!(dF[c]))
+            end
+            if isempty(dF[c])
+                Xn[:, c] = x .+ beta .* f
+            else
+                Fm = reduce(hcat, dF[c]); Xm = reduce(hcat, dX[c])
+                g = try Fm \ Vector(f) catch; zeros(T, size(Fm, 2)) end
+                all(isfinite, g) || (g = zeros(T, size(Fm, 2)))
+                Xn[:, c] = x .+ beta .* f .- (Xm .+ beta .* Fm) * g
+            end
+        end
+        Xp .= X; Fp .= Fc; have = true
+        X = Xn; X[diagind(X)] .= one(T)
+    end
+    (solution = X, iters = maxiter, ok = false)
+end
+
+"""How many *distinct* eigenvalues did the columns actually land on?
+
+The iteration's stopping test, maximum(R) < tol, only asks that each column is
+*an* eigenvector. It never asks that they are distinct, so a solve can report
+success while several columns sit on the same eigenvector.
+"""
+function distinct_eigenvalues(A, values; atol = 1e-6)
+    ref = eigen(Symmetric(A)).values; used = falses(length(ref)); n = 0
+    for v in values
+        j = argmin(abs.(ref .- v))
+        if abs(ref[j] - v) < atol && !used[j]; used[j] = true; n += 1; end
+    end
+    n
+end
+
 function solve_aa(A, k = size(A, 1); m = 50, beta = 1.0, tol = 1e-12, maxiter = 6000)
     r = anderson(rs_map(A, k), Matrix{eltype(A)}(I, size(A, 1), k);
                  m = m, beta = beta, tol = tol, maxiter = maxiter)
@@ -291,6 +340,12 @@ function experiment_enlargement(; N = 60, tmax = 1.6, dt = 0.05)
     @printf("  %-34s %.2f\n", "Anderson m=20, beta=0.2",
             reach(t -> (A = mk(t); Z = solve_aa(A; m = 20, beta = 0.2);
                         Z !== nothing && solved(A, Z.vectors, Z.values))))
+    for m in (10, 20, 50)
+        @printf("  %-34s %.2f\n", "Anderson PER-COLUMN m=$m",
+                reach(t -> (A = mk(t);
+                            r = anderson_percolumn(rs_map(A, N), Matrix{Float64}(I, N, N); m = m);
+                            r.ok && solved(A, r.solution, diag(A * r.solution)))))
+    end
 end
 
 """Anderson breaks the Re(mu) < 1 barrier that bounds ACX. The key comparison."""
@@ -305,6 +360,33 @@ function experiment_anderson(; N = 30, ts = (0.7, 0.9, 1.0, 1.1, 1.3, 1.5))
         r(Z) = (Z !== nothing && solved(A, Z.vectors, Z.values)) ? "yes" : "NO"
         @printf("%-6.2f %10.3f %7s | %-6s %-10s %s\n", t, mr, mr < 1 ? "yes" : "NO",
                 r(Zc), r(solve_aa(A; m = 50)), r(solve_aa(A; m = 50, beta = 0.2)))
+    end
+end
+
+"""Per-column Anderson converges to *duplicate* eigenvectors -- a silent failure.
+
+Contrasted against the shipped ACX path, which in this family fails loudly (huge
+residual) rather than silently, so this is a hazard of per-column Anderson and not
+a defect in the package.
+"""
+function experiment_column_collapse(; N = 60, ts = (0.80, 0.85, 0.90, 1.00))
+    mk, _ = testfamily(N)
+    println("\n== Column collapse: converged residual does not imply distinct eigenvectors ==")
+    @printf("%-6s | %-34s | %s\n", "t", "per-column Anderson m=20", "shipped ACX")
+    @printf("%-6s | %10s %10s %10s | %10s %10s\n", "", "resid", "cond(X)", "distinct", "resid", "distinct")
+    for t in ts
+        A = mk(t)
+        r = anderson_percolumn(rs_map(A, N), Matrix{Float64}(I, N, N); m = 20)
+        Zc = solve_rs(A)
+        function stats(vecs, vals)
+            (!all(isfinite, vals)) && return (Inf, 0)
+            (norm(A * vecs - vecs * Diagonal(vals)) / norm(A), distinct_eigenvalues(A, vals))
+        end
+        pr, pd = r.ok ? stats(r.solution, diag(A * r.solution)) : (Inf, 0)
+        cr, cd = Zc === nothing ? (Inf, 0) : stats(Zc.vectors, Zc.values)
+        pc = r.ok ? cond(r.solution) : Inf
+        @printf("%-6.2f | %10.2e %10.2e %7d/%-3d | %10.2e %7d/%d%s\n", t, pr, pc, pd, N, cr, cd, N,
+                (pr < 1e-10 && pd < N) ? "   <- silent collapse" : "")
     end
 end
 
@@ -330,6 +412,7 @@ end
 function run_all()
     experiment_criterion()
     experiment_anderson()
+    experiment_column_collapse()
     experiment_diagnostics()
     experiment_basin()
     experiment_enlargement()

--- a/research/basin_theory.jl
+++ b/research/basin_theory.jl
@@ -56,6 +56,62 @@ function solve_rs(A, k = size(A, 1); orders = [3, 2], tol = 1e-12, maxiter = 400
     end
 end
 
+# ------------------------------------------------- the RS map, exposed directly
+# Identical to `quadratic!`. Exposed so that ACX and Anderson can be compared on
+# the same dynamics rather than through two different drivers.
+function rs_map(A, k = size(A, 1))
+    d = diag(A); T = eltype(A); Dg = Diagonal(d)
+    G = one(T) ./ (transpose(d[1:k]) .- d)
+    (Y, X) -> begin
+        mul!(Y, A, X)
+        R = vec(mapslices(norm, Y .- X * Diagonal(Y); dims = 1))
+        mul!(Y, Dg, X, -one(T), one(T))
+        mul!(Y, X, Diagonal(Y), -one(T), one(T))
+        Y .*= G
+        Y[diagind(Y)] .= one(T)
+        R
+    end
+end
+
+# ---------------------------------------------------- Anderson acceleration
+# Walker & Ni type-II with windowed memory m. Unlike ACX, which applies a
+# fixed-shape polynomial (I + sigma(J - I))^p driven by one scalar per column,
+# Anderson builds an optimal degree-m polynomial from the residual history. It is
+# therefore not confined to the region Re(mu) < 1 -- see README.
+function anderson(F!, X0; m = 50, beta = 1.0, tol = 1e-12, maxiter = 6000)
+    X = copy(X0); Y = similar(X)
+    dX = Vector{Vector{eltype(X0)}}(); dF = Vector{Vector{eltype(X0)}}()
+    xprev = nothing; fprev = nothing
+    for k in 1:maxiter
+        R = F!(Y, X)
+        all(isfinite, Y) || return (solution = Y, iters = k, ok = false)
+        maximum(R) < tol && return (solution = copy(Y), iters = k, ok = true)
+        x = vec(copy(X)); f = vec(Y) .- x
+        if xprev !== nothing
+            push!(dX, x .- xprev); push!(dF, f .- fprev)
+            length(dX) > m && (popfirst!(dX); popfirst!(dF))
+        end
+        xprev = x; fprev = f
+        xnew = if isempty(dF)
+            x .+ beta .* f
+        else
+            Fm = reduce(hcat, dF); Xm = reduce(hcat, dX)
+            g = try Fm \ f catch; zeros(eltype(x), size(Fm, 2)) end
+            all(isfinite, g) || (g = zeros(eltype(x), size(Fm, 2)))
+            x .+ beta .* f .- (Xm .+ beta .* Fm) * g
+        end
+        X = reshape(xnew, size(X)); X[diagind(X)] .= one(eltype(X))
+    end
+    (solution = X, iters = maxiter, ok = false)
+end
+
+function solve_aa(A, k = size(A, 1); m = 50, beta = 1.0, tol = 1e-12, maxiter = 6000)
+    r = anderson(rs_map(A, k), Matrix{eltype(A)}(I, size(A, 1), k);
+                 m = m, beta = beta, tol = tol, maxiter = maxiter)
+    r.ok || return nothing
+    (vectors = r.solution, values = diag(A * r.solution), iters = r.iters)
+end
+
 # ------------------------------------------------------- Brillouin-Wigner map
 # Same fixed points as the RS map above, but with self-consistent denominators
 # lambda_j - d_i recomputed every step. Substituting lambda_j = d_j + (VX)_jj
@@ -227,6 +283,29 @@ function experiment_enlargement(; N = 60, tmax = 1.6, dt = 0.05)
                             Z !== nothing && solved(A, Z.vectors, Z.values))))
     end
     @printf("  %-34s %.2f\n", "Brillouin-Wigner denominators", reach(bw))
+    for m in (2, 5, 10, 20, 50)
+        @printf("  %-34s %.2f\n", "Anderson memory m=$m",
+                reach(t -> (A = mk(t); Z = solve_aa(A; m = m);
+                            Z !== nothing && solved(A, Z.vectors, Z.values))))
+    end
+    @printf("  %-34s %.2f\n", "Anderson m=20, beta=0.2",
+            reach(t -> (A = mk(t); Z = solve_aa(A; m = 20, beta = 0.2);
+                        Z !== nothing && solved(A, Z.vectors, Z.values))))
+end
+
+"""Anderson breaks the Re(mu) < 1 barrier that bounds ACX. The key comparison."""
+function experiment_anderson(; N = 30, ts = (0.7, 0.9, 1.0, 1.1, 1.3, 1.5))
+    mk, W = testfamily(N)
+    println("\n== ACX vs Anderson against the Re(mu) < 1 criterion ==")
+    @printf("%-6s %10s %7s | %-6s %-10s %s\n", "t", "maxRe(mu)", "Re<1?", "ACX", "AA m=50", "AA m=50 beta=0.2")
+    for t in ts
+        A = mk(t); d = diag(A)
+        mr = maximum(real, jacobian_spectrum(:rs, t * W, unit_gauge(A), d))
+        Zc = solve_rs(A)
+        r(Z) = (Z !== nothing && solved(A, Z.vectors, Z.values)) ? "yes" : "NO"
+        @printf("%-6.2f %10.3f %7s | %-6s %-10s %s\n", t, mr, mr < 1 ? "yes" : "NO",
+                r(Zc), r(solve_aa(A; m = 50)), r(solve_aa(A; m = 50, beta = 0.2)))
+    end
 end
 
 """Why block-Jacobi backfires, and how much headroom the gauge appears to offer."""
@@ -250,6 +329,7 @@ end
 
 function run_all()
     experiment_criterion()
+    experiment_anderson()
     experiment_diagnostics()
     experiment_basin()
     experiment_enlargement()

--- a/src/preparation.jl
+++ b/src/preparation.jl
@@ -5,7 +5,18 @@ function prepare(M::Union{AbstractMatrix, LinearMapAX}, diagonal, k, sort_diagon
     N = size(M, 1)
     T = eltype(M)
 
-    @timeit_debug "sort diagonal" if sort_diagonal sort_diag!(M, diagonal) end
+    P = I
+    if sort_diagonal && !issorted(diagonal)
+        # sort_diag! permutes M into the sorted basis but leaves `diagonal` alone, so
+        # reorder our copy to match: everything below indexes into the sorted basis.
+        # Rebinding rather than permuting in place keeps a caller-supplied
+        # `diagonal` untouched.
+        s = @timeit_debug "sort diagonal" sort_diag!(M, diagonal)
+        diagonal = diagonal[s]
+        # P undoes that permutation on the eigenvectors, which are otherwise returned
+        # in the sorted basis. P[s[i], i] = 1, so (P * y)[s[i]] == y[i].
+        P = sparse(s, 1:N, ones(T, N), N, N)
+    end
     if lift_degeneracies
         @timeit_debug "lift degeneracies" begin
             subspaces = degenerate_subspaces(diagonal, k, degeneracy_threshold)
@@ -23,7 +34,7 @@ function prepare(M::Union{AbstractMatrix, LinearMapAX}, diagonal, k, sort_diagon
     end
     d = view(M, diagind(M))
     @timeit_debug "build G" G = one(T) ./ (transpose(d[1:k]) .- d)
-    return M, spdiagm(d), G, T, Q
+    return M, spdiagm(d), G, T, P * Q
 end
 
 

--- a/src/preparation.jl
+++ b/src/preparation.jl
@@ -8,8 +8,15 @@ function prepare(M::Union{AbstractMatrix, LinearMapAX}, diagonal, k, sort_diagon
     @timeit_debug "sort diagonal" if sort_diagonal sort_diag!(M, diagonal) end
     if lift_degeneracies
         @timeit_debug "lift degeneracies" begin
-            Q = local_rotations(M, diagonal, k, degeneracy_threshold)
-            M = ishermitian(M) ? Q' * M * Q : Q \ Matrix(M * Q)
+            subspaces = degenerate_subspaces(diagonal, k, degeneracy_threshold)
+            if isempty(subspaces)
+                # No degeneracies: local_rotations would return exactly I, and the
+                # change of basis below would be an O(N^2) no-op. Skip both.
+                Q = I
+            else
+                Q = local_rotations(M, subspaces)
+                M = ishermitian(M) ? Q' * M * Q : Q \ Matrix(M * Q)
+            end
         end
     else
         Q = I
@@ -20,21 +27,10 @@ function prepare(M::Union{AbstractMatrix, LinearMapAX}, diagonal, k, sort_diagon
 end
 
 
-function local_rotations(M::Union{Matrix, SparseMatrixCSC}, diagonal, k, threshold = 1e-2)
-    
+function local_rotations(M::Union{Matrix, SparseMatrixCSC, LinearMapAX}, subspaces)
+
     Q = SparseMatrixCSC{eltype(M)}(I, size(M)...)
-    for subspace in degenerate_subspaces(diagonal, k, threshold)
-        Q[subspace, subspace] .= eigen( Array(view(M, subspace, subspace)) ).vectors
-    end
-    return Q
-end
-
-
-function local_rotations(M::LinearMapAX, diagonal, k, threshold = 1e-2)
-    
-    Q = SparseMatrixCSC{eltype(M)}(I, size(M)...)
-
-    for subspace in degenerate_subspaces(diagonal, k, threshold)
+    for subspace in subspaces
         Q[subspace, subspace] .= eigen( Array(view(M, subspace, subspace)) ).vectors
     end
     return Q

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using LinearAlgebra, LinearMaps
 using IterativePerturbationTheory
 using SparseArrays
+using Random
 
 N = 1000
 M = diagm(1:N) + 1e-2rand(N, N)
@@ -34,4 +35,33 @@ end
         @test Z.values ≈ eig.values[1:nev]
         @test Array(A * Z.vectors) ≈ Array(Z.vectors * Diagonal(Z.values))
     end
+end
+
+### The cases above all have an already-sorted diagonal (M, S) or opt out of sorting
+### (W), so they never exercise the sort_diagonal path on a matrix that actually needs
+### permuting. Shuffle W to cover it: same spectrum, diagonal out of order, degeneracies
+### still present.
+@testset "Unsorted diagonal (permuted H20)" begin
+    nev = 10
+    eig = eigen(W)
+    p = randperm(MersenneTwister(7), size(W, 1))
+    Wp = W[p, p]
+    @test !issorted(diag(Wp))
+
+    for A in (Wp, sparse(Wp))
+        Z = ipt(A, nev; tol = TOL)   # defaults: sort_diagonal = lift_degeneracies = true
+        @test Z.values ≈ eig.values[1:nev]
+        # eigenvectors must come back in the caller's basis, not the sorted one
+        @test Array(A * Z.vectors) ≈ Array(Z.vectors * Diagonal(Z.values))
+    end
+end
+
+### A caller-supplied `diagonal` is an input, not scratch space.
+@testset "Caller-supplied diagonal is not mutated" begin
+    q = randperm(MersenneTwister(3), size(W, 1))
+    A = W[q, q]
+    d = diag(A)
+    before = copy(d)
+    ipt(A, 10; tol = TOL, diagonal = d)
+    @test d == before
 end


### PR DESCRIPTION
Two correctness fixes in `prepare`, plus a performance change that fell out of investigating them. Both bugs were found while benchmarking `ipt` against `eigen` in the `k ≪ N` regime.

## The bugs

Both live on the `sort_diagonal` path, and both were hidden by the same gap in test coverage: every existing test case either has an **already-sorted** diagonal (`M`, `S` in the random-matrix testset, built from `diagm(1:N)`) or opts out with **`sort_diagonal = false`** (`W`, the H20 matrix). Nothing exercised sorting on a matrix that actually needed permuting.

**1. `degenerate_subspaces` was fed the unsorted diagonal.**

`sort_diag!` permutes `M` but leaves its `diagonal` argument untouched:

```julia
function sort_diag!(M::AbstractMatrix, diagonal::AbstractVector = diag(M))
    s = sortperm(diagonal)
    M .= M[s, s]
    return s          # `diagonal` itself is never reordered
end
```

so once `M` was sorted the two no longer corresponded, and degeneracy detection ran against stale values — lifting the wrong subspaces entirely.

**2. The sort permutation was never undone on the returned eigenvectors.**

They came back in the sorted basis while the caller works in the original one, so `A * X ≉ X * Diagonal(vals)` for any matrix whose diagonal wasn't already ordered. Eigenvalues were unaffected (a similarity permutation doesn't move the spectrum), which is why this was easy to miss.

On the H20 matrix under a random symmetric permutation — same spectrum, degeneracies intact, diagonal shuffled — the two compound:

| | max &#124;Δλ&#124; | residual |
|---|---|---|
| before | `NaN` (no convergence in 1000 iterations) | `NaN` |
| bug 1 fixed only | 1.3e-13 | **9.2e-01** |
| both fixed | 1.3e-13 | 4.8e-14 |

## The fixes

`prepare` now reorders a local copy of `diagonal` by the permutation `sort_diag!` returns, and folds a permutation matrix `P` into the rotation it already hands back, so the existing `X = Q * X` in `ipt!` maps eigenvectors into the caller's basis. Rebinding rather than permuting in place leaves a caller-supplied `diagonal` untouched.

## Performance

Two `O(N²)` costs in `prepare` were independent of `k`, so they dominated exactly the small-`k` regime the method is meant to be good at:

- When `degenerate_subspaces` finds nothing, `local_rotations` builds an **exact** sparse identity and the following `Q' * M * Q` (or `Q \ Matrix(M * Q)`) is a mathematical no-op — plus, in the non-symmetric case, a `Matrix()` allocation and a sparse solve. Now short-circuited to `Q = I`.
- When the diagonal is already sorted, `sortperm` returns `1:N` and `M .= M[s, s]` copies the matrix onto itself. Now skipped. Exact, not an approximation.

`local_rotations` takes the subspaces directly instead of recomputing them, which also collapses its two byte-identical methods into one.

Min-of-30 on `diagm(1:N) + 1e-3*randn(N, N)`, N = 1000, both commits together:

```
nonsym   k=1      before 0.010290   after 0.003847   2.67x
nonsym   k=10     before 0.014461   after 0.007713   1.87x
nonsym   k=100    before 0.033433   after 0.023146   1.44x
sym      k=1      before 0.011540   after 0.003772   3.06x
sym      k=10     before 0.016225   after 0.007587   2.14x
sym      k=100    before 0.034678   after 0.022844   1.52x
```

Against a full `eigen()` at N = 1000, k = 1: non-symmetric goes from 68x to ~180x, symmetric from 12x to ~40x. Neutral at `k = N`, where the removed `O(N²)` is lost in the `O(N²k)` iteration.

As a side effect a sparse non-symmetric `M` now stays sparse through `prepare` instead of being densified by the `Matrix()` call. That path is covered for correctness but its speedup is unmeasured.

## Verification

- Existing suite passes unchanged.
- Output is **bit-identical** before/after across dense/sparse × symmetric/non-symmetric × degenerate/non-degenerate for every case that was already correct — eigenvalue hashes and vector sums match exactly, as expected since the skipped operations were exact identities.
- New tests fail **4/5** without the `src/preparation.jl` change and pass 5/5 with it. The `diagonal`-mutation test is a guard against the in-place alternative, not a caught regression.

## Two things left alone

- `sort_diag!` has no `LinearMapAX` method, so `ipt(LinearMap(A), k)` errors on the default `sort_diagonal = true`. The existing test passes `sort_diagonal = false`, which sidesteps it. Fixing it needs a real decision about what sorting even means for a matrix-free operator.
- `degenerate_subspaces` truncates at `k` (`head:min(tail, k)`), so a degenerate multiplet straddling the `k` boundary is cut in half and the resulting rotation won't diagonalize the block. The `min` suggests this was deliberate; extending past `k` would pull columns beyond the requested range into `Q`, which is a design call rather than a bug fix.

Benchmarks were run on Julia 1.12.6, OpenBLAS, 2 BLAS threads. Worth re-checking on your setup — the absolute numbers are noisy on this box, and I had to raise the sample count to get monotone timings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYFRYPVSSF6fMXnLaxLPHT)_